### PR TITLE
Three rule management options

### DIFF
--- a/optionOne/README.md
+++ b/optionOne/README.md
@@ -1,0 +1,72 @@
+# Option 1: Variable-Based Configuration
+
+This approach uses complex Terraform variables to define all firewall rules and rule collections in a structured format.
+
+## 📁 Files
+
+- `main.tf` - Main Terraform configuration with for_each loops
+- `variables.tf` - Complex variable definitions with type validation  
+- `locals.tf` - Azure regions list
+- `terraform.tfvars` - Complete rule configuration in variables
+
+## 🚀 How to Deploy
+
+```powershell
+# Navigate to option directory
+cd optionOne
+
+# Initialize and deploy
+terraform init
+terraform plan -var-file="terraform.tfvars"
+terraform apply -var-file="terraform.tfvars"
+```
+
+## ✅ Pros
+
+- **Type Safety**: Full Terraform type validation
+- **IntelliSense**: IDE autocomplete support
+- **Documentation**: Built-in variable descriptions
+- **Native**: Pure Terraform approach
+
+## ❌ Cons
+
+- **Complexity**: Extremely verbose for large rule sets
+- **Maintenance**: Requires deep Terraform knowledge
+- **Scalability**: Becomes unwieldy with many rules
+- **User-Friendly**: Not accessible to non-Terraform users
+
+## 🎯 Best For
+
+- Small, static rule sets (< 50 rules)
+- Teams of only Terraform experts
+- When type safety is critical
+- Simple, single-environment deployments
+
+## 📝 Adding New Rules
+
+To add new rules, modify the `firewall_rule_collection_groups` variable in `terraform.tfvars`:
+
+```hcl
+firewall_rule_collection_groups = {
+  existing_group = { ... }
+  
+  # Add new group
+  custom_app = {
+    priority = 4000
+    network_rule_collections = [{
+      action   = "Allow"
+      name     = "CustomAppRules"
+      priority = 500
+      rules = [
+        {
+          name              = "Database Access"
+          source_addresses  = ["10.0.0.0/24"]
+          destination_fqdns = ["myapp.database.com"]
+          protocols         = ["TCP"]
+          destination_ports = ["3306"]
+        }
+      ]
+    }]
+  }
+}
+```

--- a/optionOne/main.tf
+++ b/optionOne/main.tf
@@ -1,0 +1,64 @@
+# Option 1: Main configuration using for_each with structured variables
+
+resource "azurerm_resource_group" "azfw-rg" {
+  location = var.location
+  name     = var.resource_group_name
+}
+
+module "firewall_policy" {
+  source = "Azure/avm-res-network-firewallpolicy/azurerm"
+  enable_telemetry    = var.enable_telemetry
+  name                = var.firewall_policy_name
+  location            = var.location
+  resource_group_name = azurerm_resource_group.azfw-rg.name
+  firewall_policy_dns = {
+    proxy_enabled = true
+  }
+}
+
+# Dynamic rule collection groups using for_each
+module "rule_collection_groups" {
+  source   = "Azure/avm-res-network-firewallpolicy/azurerm//modules/rule_collection_groups"
+  for_each = var.firewall_rule_collection_groups
+
+  firewall_policy_rule_collection_group_firewall_policy_id = module.firewall_policy.resource.id
+  firewall_policy_rule_collection_group_name               = "${title(each.key)}RuleCollectionGroup"
+  firewall_policy_rule_collection_group_priority           = each.value.priority
+
+  # Network rule collections
+  firewall_policy_rule_collection_group_network_rule_collection = [
+    for collection in each.value.network_rule_collections : {
+      action   = collection.action
+      name     = collection.name
+      priority = collection.priority
+      rule = [
+        for rule in collection.rules : {
+          name                  = rule.name
+          source_addresses      = rule.source_addresses
+          destination_fqdns     = rule.destination_fqdns
+          destination_addresses = rule.destination_addresses
+          protocols             = rule.protocols
+          destination_ports     = rule.destination_ports
+        }
+      ]
+    }
+  ]
+
+  # Application rule collections
+  firewall_policy_rule_collection_group_application_rule_collection = [
+    for collection in each.value.application_rule_collections : {
+      action   = collection.action
+      name     = collection.name
+      priority = collection.priority
+      rule = [
+        for rule in collection.rules : {
+          name                  = rule.name
+          source_addresses      = rule.source_addresses
+          destination_fqdns     = rule.destination_fqdns
+          destination_fqdn_tags = rule.destination_fqdn_tags
+          protocols             = rule.protocols
+        }
+      ]
+    }
+  ]
+}

--- a/optionOne/terraform.tf
+++ b/optionOne/terraform.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.71, < 5.0.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.0, < 4.0.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = ""
+}

--- a/optionOne/terraform.tfvars
+++ b/optionOne/terraform.tfvars
@@ -1,0 +1,218 @@
+# Option 1: terraform.tfvars for variable-based configuration
+enable_telemetry = true
+location = "australiaeast"
+firewall_policy_name = "azfw-policy-option1"
+resource_group_name = "azfwpolicy-rg-option1"
+
+firewall_rule_collection_groups = {
+  avd_core = {
+    priority = 1000
+    network_rule_collections = [{
+      action   = "Allow"
+      name     = "AVDCoreNetworkRules"
+      priority = 500
+      rules = [
+        {
+          name              = "Login to Microsoft"
+          source_addresses  = ["10.100.0.0/24"]
+          destination_fqdns = ["login.microsoftonline.com"]
+          protocols         = ["TCP"]
+          destination_ports = ["443"]
+        },
+        {
+          name                  = "AVD"
+          source_addresses      = ["10.100.0.0/24"]
+          destination_addresses = ["WindowsVirtualDesktop", "AzureFrontDoor.Frontend", "AzureMonitor"]
+          protocols             = ["TCP"]
+          destination_ports     = ["443"]
+        },
+        {
+          name              = "GCS"
+          source_addresses  = ["10.100.0.0/24"]
+          destination_fqdns = ["gcs.prod.monitoring.core.windows.net"]
+          protocols         = ["TCP"]
+          destination_ports = ["443"]
+        },
+        {
+          name                  = "DNS"
+          source_addresses      = ["10.100.0.0/24"]
+          destination_addresses = ["AzureDNS"]
+          protocols             = ["TCP", "UDP"]
+          destination_ports     = ["53"]
+        },
+        {
+          name              = "azkms"
+          source_addresses  = ["10.100.0.0/24"]
+          destination_fqdns = ["azkms.core.windows.net"]
+          protocols         = ["TCP"]
+          destination_ports = ["1688"]
+        },
+        {
+          name              = "KMS"
+          source_addresses  = ["10.100.0.0/24"]
+          destination_fqdns = ["kms.core.windows.net"]
+          protocols         = ["TCP"]
+          destination_ports = ["1688"]
+        },
+        {
+          name              = "mrglobalblob"
+          source_addresses  = ["10.100.0.0/24"]
+          destination_fqdns = ["mrsglobalsteus2prod.blob.core.windows.net"]
+          protocols         = ["TCP"]
+          destination_ports = ["443"]
+        },
+        {
+          name              = "wvdportalstorageblob"
+          source_addresses  = ["10.100.0.0/24"]
+          destination_fqdns = ["wvdportalstorageblob.blob.core.windows.net"]
+          protocols         = ["TCP"]
+          destination_ports = ["443"]
+        },
+        {
+          name              = "oneocsp"
+          source_addresses  = ["10.100.0.0/24"]
+          destination_fqdns = ["oneocsp.microsoft.com"]
+          protocols         = ["TCP"]
+          destination_ports = ["443"]
+        },
+        {
+          name              = "microsoft.com"
+          source_addresses  = ["10.100.0.0/24"]
+          destination_fqdns = ["www.microsoft.com"]
+          protocols         = ["TCP"]
+          destination_ports = ["443"]
+        }
+      ]
+    }]
+  }
+  
+  avd_optional = {
+    priority = 1050
+    network_rule_collections = [{
+      action   = "Allow"
+      name     = "AVDOptionalNetworkRules"
+      priority = 500
+      rules = [
+        {
+          name              = "time"
+          source_addresses  = ["10.0.0.0/24"]
+          destination_fqdns = ["time.windows.com"]
+          protocols         = ["UDP"]
+          destination_ports = ["123"]
+        },
+        {
+          name              = "login windows.net"
+          source_addresses  = ["10.0.0.0/24"]
+          destination_fqdns = ["login.windows.net"]
+          protocols         = ["TCP"]
+          destination_ports = ["443"]
+        },
+        {
+          name              = "msftconnecttest"
+          source_addresses  = ["10.0.0.0/24"]
+          destination_fqdns = ["www.msftconnecttest.com"]
+          protocols         = ["TCP"]
+          destination_ports = ["443"]
+        }
+      ]
+    }]
+    application_rule_collections = [{
+      action   = "Allow"
+      name     = "AVDOptionalApplicationRules"
+      priority = 600
+      rules = [
+        {
+          name                  = "Windows"
+          source_addresses      = ["10.0.0.0/24"]
+          destination_fqdn_tags = ["WindowsUpdate", "WindowsDiagnostics", "MicrosoftActiveProtectionService"]
+          protocols = [
+            {
+              port = 443
+              type = "Https"
+            }
+          ]
+        },
+        {
+          name              = "Events"
+          source_addresses  = ["10.0.0.0/24"]
+          destination_fqdns = ["*.events.data.microsoft.com"]
+          protocols = [
+            {
+              port = 443
+              type = "Https"
+            }
+          ]
+        },
+        {
+          name              = "sfx"
+          source_addresses  = ["10.0.0.0/24"]
+          destination_fqdns = ["*.sfx.ms"]
+          protocols = [
+            {
+              port = 443
+              type = "Https"
+            }
+          ]
+        },
+        {
+          name              = "digicert"
+          source_addresses  = ["10.0.0.0/24"]
+          destination_fqdns = ["*.digicert.com"]
+          protocols = [
+            {
+              port = 443
+              type = "Https"
+            }
+          ]
+        },
+        {
+          name              = "Azure DNS"
+          source_addresses  = ["10.0.0.0/24"]
+          destination_fqdns = ["*.azure-dns.com", "*.azure-dns.net"]
+          protocols = [
+            {
+              port = 443
+              type = "Https"
+            }
+          ]
+        }
+      ]
+    }]
+  }
+
+  m365 = {
+    priority = 2000
+    network_rule_collections = [{
+      action   = "Allow"
+      name     = "M365NetworkRules"
+      priority = 500
+      rules = [
+        {
+          name                  = "M365"
+          source_addresses      = ["10.0.0.0/24"]
+          destination_addresses = ["Office365.Common.Allow.Required"]
+          protocols             = ["TCP"]
+          destination_ports     = ["443"]
+        }
+      ]
+    }]
+  }
+
+  internet = {
+    priority = 3000
+    network_rule_collections = [{
+      action   = "Allow"
+      name     = "InternetNetworkRules"
+      priority = 500
+      rules = [
+        {
+          name                  = "Internet"
+          source_addresses      = ["10.0.0.0/24"]
+          destination_addresses = ["*"]
+          protocols             = ["TCP"]
+          destination_ports     = ["443", "80"]
+        }
+      ]
+    }]
+  }
+}

--- a/optionOne/variables.tf
+++ b/optionOne/variables.tf
@@ -1,0 +1,136 @@
+# Option 1: Variable-based configuration
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+This variable controls whether or not telemetry is enabled for the module.
+For more information see https://aka.ms/avm/telemetryinfo.
+If it is set to false, then no telemetry will be collected.
+DESCRIPTION
+}
+
+variable "location" {
+  type        = string
+  default     = "australiaeast"
+  description = "The Azure region where resources will be deployed"
+}
+
+variable "firewall_policy_name" {
+  type        = string
+  default     = "azfw-policy-option1"
+  description = "The name of the firewall policy"
+}
+
+variable "resource_group_name" {
+  type        = string
+  default     = "azfwpolicy-rg-option1"
+  description = "The name of the resource group"
+}
+
+variable "firewall_rule_collection_groups" {
+  type = map(object({
+    priority = number
+    network_rule_collections = optional(list(object({
+      action   = string
+      name     = string
+      priority = number
+      rules = list(object({
+        name                  = string
+        source_addresses      = list(string)
+        destination_fqdns     = optional(list(string))
+        destination_addresses = optional(list(string))
+        protocols             = list(string)
+        destination_ports     = list(string)
+      }))
+    })), [])
+    application_rule_collections = optional(list(object({
+      action   = string
+      name     = string
+      priority = number
+      rules = list(object({
+        name                  = string
+        source_addresses      = list(string)
+        destination_fqdns     = optional(list(string))
+        destination_fqdn_tags = optional(list(string))
+        protocols = list(object({
+          port = number
+          type = string
+        }))
+      }))
+    })), [])
+  }))
+  description = "Map of firewall rule collection groups with their configurations"
+  default = {
+    avd_core = {
+      priority = 1000
+      network_rule_collections = [{
+        action   = "Allow"
+        name     = "AVDCoreNetworkRules"
+        priority = 500
+        rules = [
+          {
+            name              = "Login to Microsoft"
+            source_addresses  = ["10.100.0.0/24"]
+            destination_fqdns = ["login.microsoftonline.com"]
+            protocols         = ["TCP"]
+            destination_ports = ["443"]
+          },
+          {
+            name                  = "AVD"
+            source_addresses      = ["10.100.0.0/24"]
+            destination_addresses = ["WindowsVirtualDesktop", "AzureFrontDoor.Frontend", "AzureMonitor"]
+            protocols             = ["TCP"]
+            destination_ports     = ["443"]
+          },
+          {
+            name              = "GCS"
+            source_addresses  = ["10.100.0.0/24"]
+            destination_fqdns = ["gcs.prod.monitoring.core.windows.net"]
+            protocols         = ["TCP"]
+            destination_ports = ["443"]
+          },
+          {
+            name                  = "DNS"
+            source_addresses      = ["10.100.0.0/24"]
+            destination_addresses = ["AzureDNS"]
+            protocols             = ["TCP", "UDP"]
+            destination_ports     = ["53"]
+          }
+        ]
+      }]
+    }
+    avd_optional = {
+      priority = 1050
+      network_rule_collections = [{
+        action   = "Allow"
+        name     = "AVDOptionalNetworkRules"
+        priority = 500
+        rules = [
+          {
+            name              = "time"
+            source_addresses  = ["10.0.0.0/24"]
+            destination_fqdns = ["time.windows.com"]
+            protocols         = ["UDP"]
+            destination_ports = ["123"]
+          }
+        ]
+      }]
+      application_rule_collections = [{
+        action   = "Allow"
+        name     = "AVDOptionalApplicationRules"
+        priority = 600
+        rules = [
+          {
+            name                  = "Windows"
+            source_addresses      = ["10.0.0.0/24"]
+            destination_fqdn_tags = ["WindowsUpdate", "WindowsDiagnostics", "MicrosoftActiveProtectionService"]
+            protocols = [{
+              port = 443
+              type = "Https"
+            }]
+          }
+        ]
+      }]
+    }
+  }
+}

--- a/optionThree/README.md
+++ b/optionThree/README.md
@@ -1,0 +1,102 @@
+# Option 3: Template-Based Configuration
+
+This approach uses predefined rule templates and combines them based on configuration variables for standardized deployments.
+
+## 📁 Files
+
+- `main.tf` - Main Terraform configuration using templates
+- `variables.tf` - Template control variables
+- `locals.tf` - Rule templates and composition logic
+- `terraform.tfvars` - Template selection and network configuration
+
+## 🚀 How to Deploy
+
+```powershell
+# Navigate to option directory
+cd optionThree
+
+# Initialize and deploy
+terraform init
+terraform plan -var-file="terraform.tfvars"
+terraform apply -var-file="terraform.tfvars"
+```
+
+## ✅ Pros
+
+- **Templates**: Reusable, standardized rule definitions
+- **Network Abstraction**: Centralized subnet management
+- **Selective**: Easy to enable/disable rule groups
+- **Consistency**: Enforced rule structure across environments
+
+## ❌ Cons
+
+- **Template Editing**: Adding new rules requires modifying locals
+- **Flexibility**: Limited to predefined template combinations  
+- **Learning Curve**: Must understand template structure
+- **Custom Rules**: Difficult to add one-off rules
+
+## 🎯 Best For
+
+- Standardized, repeatable rule patterns
+- Multi-environment deployments with consistent rules
+- Network segment abstraction requirements
+- Teams that prefer compositional over declarative approach
+
+## 📝 Configuration
+
+### Enable/Disable Rule Sets
+
+```hcl
+# In terraform.tfvars
+enabled_rule_sets = ["avd_core", "avd_optional", "m365", "internet"]
+```
+
+### Network Segments
+
+```hcl
+# In terraform.tfvars  
+network_segments = {
+  avd_subnet     = "10.100.0.0/24"
+  general_subnet = "10.0.0.0/24"
+  dmz_subnet     = "10.200.0.0/24"
+}
+```
+
+### Adding New Templates
+
+To add new rule templates, modify the `rule_templates` in `locals.tf`:
+
+```hcl
+# In locals.tf
+rule_templates = {
+  # Existing templates...
+  
+  custom_app_rules = [
+    {
+      name              = "Database Access"
+      destination_fqdns = ["myapp.database.com"]
+      protocols         = ["TCP"]
+      destination_ports = ["3306"]
+    }
+  ]
+}
+```
+
+Then add the template configuration:
+
+```hcl
+# In locals.tf
+rule_collection_configs = {
+  # Existing configs...
+  
+  custom_app = {
+    network_collections = [{
+      action        = "Allow"
+      name          = "CustomAppRules"
+      priority      = 500
+      rules         = local.rule_templates.custom_app_rules
+      source_subnet = var.network_segments.general_subnet
+    }]
+  }
+}
+```

--- a/optionThree/locals.tf
+++ b/optionThree/locals.tf
@@ -1,0 +1,222 @@
+locals {
+  # Rule templates - reusable rule definitions
+  rule_templates = {
+    # AVD Core Rules
+    avd_core_rules = [
+      {
+        name              = "Login to Microsoft"
+        destination_fqdns = ["login.microsoftonline.com"]
+        protocols         = ["TCP"]
+        destination_ports = ["443"]
+      },
+      {
+        name                  = "AVD"
+        destination_addresses = ["WindowsVirtualDesktop", "AzureFrontDoor.Frontend", "AzureMonitor"]
+        protocols             = ["TCP"]
+        destination_ports     = ["443"]
+      },
+      {
+        name              = "GCS"
+        destination_fqdns = ["gcs.prod.monitoring.core.windows.net"]
+        protocols         = ["TCP"]
+        destination_ports = ["443"]
+      },
+      {
+        name                  = "DNS"
+        destination_addresses = ["AzureDNS"]
+        protocols             = ["TCP", "UDP"]
+        destination_ports     = ["53"]
+      },
+      {
+        name              = "azkms"
+        destination_fqdns = ["azkms.core.windows.net"]
+        protocols         = ["TCP"]
+        destination_ports = ["1688"]
+      },
+      {
+        name              = "KMS"
+        destination_fqdns = ["kms.core.windows.net"]
+        protocols         = ["TCP"]
+        destination_ports = ["1688"]
+      },
+      {
+        name              = "mrglobalblob"
+        destination_fqdns = ["mrsglobalsteus2prod.blob.core.windows.net"]
+        protocols         = ["TCP"]
+        destination_ports = ["443"]
+      },
+      {
+        name              = "wvdportalstorageblob"
+        destination_fqdns = ["wvdportalstorageblob.blob.core.windows.net"]
+        protocols         = ["TCP"]
+        destination_ports = ["443"]
+      },
+      {
+        name              = "oneocsp"
+        destination_fqdns = ["oneocsp.microsoft.com"]
+        protocols         = ["TCP"]
+        destination_ports = ["443"]
+      },
+      {
+        name              = "microsoft.com"
+        destination_fqdns = ["www.microsoft.com"]
+        protocols         = ["TCP"]
+        destination_ports = ["443"]
+      }
+    ]
+
+    # AVD Optional Network Rules
+    avd_optional_network_rules = [
+      {
+        name              = "time"
+        destination_fqdns = ["time.windows.com"]
+        protocols         = ["UDP"]
+        destination_ports = ["123"]
+      },
+      {
+        name              = "login windows.net"
+        destination_fqdns = ["login.windows.net"]
+        protocols         = ["TCP"]
+        destination_ports = ["443"]
+      },
+      {
+        name              = "msftconnecttest"
+        destination_fqdns = ["www.msftconnecttest.com"]
+        protocols         = ["TCP"]
+        destination_ports = ["443"]
+      }
+    ]
+
+    # AVD Optional Application Rules
+    avd_optional_application_rules = [
+      {
+        name                  = "Windows"
+        destination_fqdn_tags = ["WindowsUpdate", "WindowsDiagnostics", "MicrosoftActiveProtectionService"]
+        protocols = [{
+          port = 443
+          type = "Https"
+        }]
+      },
+      {
+        name              = "Events"
+        destination_fqdns = ["*.events.data.microsoft.com"]
+        protocols = [{
+          port = 443
+          type = "Https"
+        }]
+      },
+      {
+        name              = "sfx"
+        destination_fqdns = ["*.sfx.ms"]
+        protocols = [{
+          port = 443
+          type = "Https"
+        }]
+      },
+      {
+        name              = "digicert"
+        destination_fqdns = ["*.digicert.com"]
+        protocols = [{
+          port = 443
+          type = "Https"
+        }]
+      },
+      {
+        name              = "Azure DNS"
+        destination_fqdns = ["*.azure-dns.com", "*.azure-dns.net"]
+        protocols = [{
+          port = 443
+          type = "Https"
+        }]
+      }
+    ]
+
+    # M365 Rules
+    m365_rules = [
+      {
+        name                  = "M365"
+        destination_addresses = ["Office365.Common.Allow.Required"]
+        protocols             = ["TCP"]
+        destination_ports     = ["443"]
+      }
+    ]
+
+    # Internet Rules
+    internet_rules = [
+      {
+        name                  = "Internet"
+        destination_addresses = ["*"]
+        protocols             = ["TCP"]
+        destination_ports     = ["443", "80"]
+      }
+    ]
+  }
+
+  # Rule collection configurations
+  rule_collection_configs = {
+    avd_core = {
+      network_collections = [
+        {
+          action     = "Allow"
+          name       = "AVDCoreNetworkRules"
+          priority   = 500
+          rules      = local.rule_templates.avd_core_rules
+          source_subnet = var.network_segments.avd_subnet
+        }
+      ]
+    }
+
+    avd_optional = {
+      network_collections = [
+        {
+          action     = "Allow"
+          name       = "AVDOptionalNetworkRules"
+          priority   = 500
+          rules      = local.rule_templates.avd_optional_network_rules
+          source_subnet = var.network_segments.general_subnet
+        }
+      ]
+      application_collections = [
+        {
+          action     = "Allow"
+          name       = "AVDOptionalApplicationRules"
+          priority   = 600
+          rules      = local.rule_templates.avd_optional_application_rules
+          source_subnet = var.network_segments.general_subnet
+        }
+      ]
+    }
+
+    m365 = {
+      network_collections = [
+        {
+          action     = "Allow"
+          name       = "M365NetworkRules"
+          priority   = 500
+          rules      = local.rule_templates.m365_rules
+          source_subnet = var.network_segments.general_subnet
+        }
+      ]
+    }
+
+    internet = {
+      network_collections = [
+        {
+          action     = "Allow"
+          name       = "InternetNetworkRules"
+          priority   = 500
+          rules      = local.rule_templates.internet_rules
+          source_subnet = var.network_segments.general_subnet
+        }
+      ]
+    }
+  }
+
+  # Build final configuration for enabled rule sets
+  enabled_rule_collections = {
+    for rule_set in var.enabled_rule_sets : rule_set => {
+      priority = var.rule_collection_group_priorities[rule_set]
+      config   = local.rule_collection_configs[rule_set]
+    }
+  }
+}

--- a/optionThree/main.tf
+++ b/optionThree/main.tf
@@ -1,0 +1,64 @@
+# Option 3: Modular approach with rule templates
+
+resource "azurerm_resource_group" "azfw-rg" {
+  location = var.location
+  name     = var.resource_group_name
+}
+
+module "firewall_policy" {
+  source = "Azure/avm-res-network-firewallpolicy/azurerm"
+  enable_telemetry    = var.enable_telemetry
+  name                = var.firewall_policy_name
+  location            = var.location
+  resource_group_name = azurerm_resource_group.azfw-rg.name
+  firewall_policy_dns = {
+    proxy_enabled = true
+  }
+}
+
+# Dynamic rule collection groups using template-based approach
+module "rule_collection_groups" {
+  source   = "Azure/avm-res-network-firewallpolicy/azurerm//modules/rule_collection_groups"
+  for_each = local.enabled_rule_collections
+
+  firewall_policy_rule_collection_group_firewall_policy_id = module.firewall_policy.resource.id
+  firewall_policy_rule_collection_group_name               = "${title(each.key)}RuleCollectionGroup"
+  firewall_policy_rule_collection_group_priority           = each.value.priority
+
+  # Network rule collections
+  firewall_policy_rule_collection_group_network_rule_collection = [
+    for collection in try(each.value.config.network_collections, []) : {
+      action   = collection.action
+      name     = collection.name
+      priority = collection.priority
+      rule = [
+        for rule in collection.rules : {
+          name                  = rule.name
+          source_addresses      = [collection.source_subnet]
+          destination_fqdns     = try(rule.destination_fqdns, null)
+          destination_addresses = try(rule.destination_addresses, null)
+          protocols             = rule.protocols
+          destination_ports     = rule.destination_ports
+        }
+      ]
+    }
+  ]
+
+  # Application rule collections
+  firewall_policy_rule_collection_group_application_rule_collection = [
+    for collection in try(each.value.config.application_collections, []) : {
+      action   = collection.action
+      name     = collection.name
+      priority = collection.priority
+      rule = [
+        for rule in collection.rules : {
+          name                  = rule.name
+          source_addresses      = [collection.source_subnet]
+          destination_fqdns     = try(rule.destination_fqdns, null)
+          destination_fqdn_tags = try(rule.destination_fqdn_tags, null)
+          protocols             = rule.protocols
+        }
+      ]
+    }
+  ]
+}

--- a/optionThree/terraform.tf
+++ b/optionThree/terraform.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.71, < 5.0.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.0, < 4.0.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = ""
+}

--- a/optionThree/terraform.tfvars
+++ b/optionThree/terraform.tfvars
@@ -1,0 +1,24 @@
+# Option 3: terraform.tfvars for modular template approach
+enable_telemetry = true
+location = "australiaeast"
+firewall_policy_name = "azfw-policy-option3"
+resource_group_name = "azfwpolicy-rg-option3"
+
+# Network segments configuration
+network_segments = {
+  avd_subnet     = "10.100.0.0/24"
+  general_subnet = "10.0.0.0/24"
+  dmz_subnet     = "10.200.0.0/24"
+}
+
+# Which rule sets to enable
+enabled_rule_sets = ["avd_core", "avd_optional", "m365", "internet"]
+
+# Priority configuration for rule collection groups
+rule_collection_group_priorities = {
+  avd_core     = 1000
+  avd_optional = 1050
+  m365         = 2000
+  internet     = 3000
+  custom       = 4000
+}

--- a/optionThree/variables.tf
+++ b/optionThree/variables.tf
@@ -1,0 +1,54 @@
+# Option 3: Modular approach with rule templates
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+This variable controls whether or not telemetry is enabled for the module.
+For more information see https://aka.ms/avm/telemetryinfo.
+If it is set to false, then no telemetry will be collected.
+DESCRIPTION
+}
+
+variable "location" {
+  type        = string
+  default     = "australiaeast"
+  description = "The Azure region where resources will be deployed"
+}
+
+variable "firewall_policy_name" {
+  type        = string
+  default     = "azfw-policy-option3"
+  description = "The name of the firewall policy"
+}
+
+variable "resource_group_name" {
+  type        = string
+  default     = "azfwpolicy-rg-option3"
+  description = "The name of the resource group"
+}
+
+variable "network_segments" {
+  type = map(string)
+  description = "Map of network segments and their CIDR blocks"
+  default = {
+    avd_subnet = "10.100.0.0/24"
+    general_subnet = "10.0.0.0/24"
+  }
+}
+
+variable "enabled_rule_sets" {
+  type = list(string)
+  description = "List of rule sets to enable"
+  default = ["avd_core", "avd_optional", "m365", "internet"]
+}
+
+variable "rule_collection_group_priorities" {
+  type = map(number)
+  description = "Priority mapping for rule collection groups"
+  default = {
+    avd_core = 1000
+    avd_optional = 1050
+    m365 = 2000
+    internet = 3000
+  }
+}

--- a/optionTwo/README.md
+++ b/optionTwo/README.md
@@ -1,0 +1,99 @@
+# Option 2: YAML-Based Configuration
+
+This approach uses external YAML files to define firewall rules, providing the best balance of simplicity, maintainability, and scalability.
+
+## 📁 Files
+
+- `main.tf` - Main Terraform configuration with YAML parsing
+- `variables.tf` - Simple variable definitions
+- `locals.tf` - YAML loading and processing logic
+- `terraform.tfvars` - Basic deployment values
+- `terraform_nonprod.tfvars` - Non-production environment configuration
+- `terraform_prod.tfvars` - Production environment configuration
+- `firewall_rules.yaml` - Main rule configuration file
+- `firewall_rules_nonprod.yaml` - Non-production-specific rules
+- `firewall_rules_prod.yaml` - Production-specific rules
+- `validate-firewall-rules.ps1` - PowerShell validation script
+
+## 🚀 Quick Start
+
+### 1. Validate Your Configuration (Optional)
+```powershell
+# Validate YAML syntax and structure
+.\validate-firewall-rules.ps1 -YamlFile "firewall_rules.yaml"
+```
+
+### 2. Deploy Option 2
+```powershell
+# Deploy with main configuration
+terraform init
+terraform plan -var-file="terraform.tfvars"
+terraform apply -var-file="terraform.tfvars"
+```
+
+### 3. Environment-Specific Deployments
+```powershell
+# Non-production environment
+terraform init
+terraform plan -var-file="terraform_nonprod.tfvars"
+terraform apply -var-file="terraform_nonprod.tfvars"
+
+# Production environment
+terraform init
+terraform plan -var-file="terraform_prod.tfvars"
+terraform apply -var-file="terraform_prod.tfvars"
+```
+
+## Key Benefits of Option 2
+
+### ✅ **Best Practices Included**
+- Environment-aware configuration
+- Default subnet management
+- Comprehensive validation
+- Resource tagging
+- Output summaries for debugging
+
+### ✅ **Operational Excellence**
+- Pre-deployment validation script
+- Clear error messages
+- Configuration summary outputs
+- Environment-specific defaults
+
+### ✅ **Security & Compliance**
+- Separation of infrastructure and rules
+- Version-controlled rule changes
+- Environment isolation
+- Audit-friendly configuration files
+
+### ✅ **Developer Experience**
+- Simple YAML syntax
+- Clear deployment guide
+- Comprehensive examples
+- Error validation
+
+## Comparison Summary
+
+| Feature | Option 1 (Variables) | **Option 2 (YAML)** ⭐ | Option 3 (Templates) |
+|---------|---------------------|---------------------|---------------------|
+| Ease of Use | ⚠️ Complex | ✅ Simple | ⚠️ Medium |
+| Maintainability | ❌ Poor | ✅ Excellent | ⚠️ Good |
+| Non-Dev Friendly | ❌ No | ✅ Yes | ❌ No |
+| Environment Support | ⚠️ Limited | ✅ Excellent | ⚠️ Good |
+| Validation | ✅ Built-in | ✅ Custom Script | ❌ None |
+| Scalability | ❌ Poor | ✅ Excellent | ⚠️ Good |
+
+## Why Option 2 Wins
+
+1. **Practical**: Security teams can modify rules without Terraform knowledge
+2. **Scalable**: Easy to add hundreds of rules without code complexity  
+3. **Flexible**: Environment-specific configurations are trivial
+4. **Maintainable**: Clean separation of concerns
+5. **Future-proof**: Can add validation, automation, and tooling around YAML files
+
+## Next Steps
+
+1. **Start with Option 2** - It provides the best foundation
+2. **Customize** the validation script for your organization's requirements  
+3. **Create** environment-specific YAML files as needed
+4. **Implement** CI/CD validation using the PowerShell script
+5. **Scale** by adding more rule groups as your infrastructure grows

--- a/optionTwo/firewall_rules.yaml
+++ b/optionTwo/firewall_rules.yaml
@@ -1,0 +1,141 @@
+avd_core:
+  priority: 1000
+  network_rule_collections:
+    - action: "Allow"
+      name: "AVDCoreNetworkRules"
+      priority: 500
+      rules:
+        - name: "Login to Microsoft"
+          source_addresses: ["10.100.0.0/24"]
+          destination_fqdns: ["login.microsoftonline.com"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+        - name: "AVD"
+          source_addresses: ["10.100.0.0/24"]
+          destination_addresses: ["WindowsVirtualDesktop", "AzureFrontDoor.Frontend", "AzureMonitor"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+        - name: "GCS"
+          source_addresses: ["10.100.0.0/24"]
+          destination_fqdns: ["gcs.prod.monitoring.core.windows.net"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+        - name: "DNS"
+          source_addresses: ["10.100.0.0/24"]
+          destination_addresses: ["AzureDNS"]
+          protocols: ["TCP", "UDP"]
+          destination_ports: ["53"]
+        - name: "azkms"
+          source_addresses: ["10.100.0.0/24"]
+          destination_fqdns: ["azkms.core.windows.net"]
+          protocols: ["TCP"]
+          destination_ports: ["1688"]
+        - name: "KMS"
+          source_addresses: ["10.100.0.0/24"]
+          destination_fqdns: ["kms.core.windows.net"]
+          protocols: ["TCP"]
+          destination_ports: ["1688"]
+        - name: "mrglobalblob"
+          source_addresses: ["10.100.0.0/24"]
+          destination_fqdns: ["mrsglobalsteus2prod.blob.core.windows.net"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+        - name: "wvdportalstorageblob"
+          source_addresses: ["10.100.0.0/24"]
+          destination_fqdns: ["wvdportalstorageblob.blob.core.windows.net"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+        - name: "oneocsp"
+          source_addresses: ["10.100.0.0/24"]
+          destination_fqdns: ["oneocsp.microsoft.com"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+        - name: "microsoft.com"
+          source_addresses: ["10.100.0.0/24"]
+          destination_fqdns: ["www.microsoft.com"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+
+avd_optional:
+  priority: 1050
+  network_rule_collections:
+    - action: "Allow"
+      name: "AVDOptionalNetworkRules"
+      priority: 500
+      rules:
+        - name: "time"
+          source_addresses: ["10.0.0.0/24"]
+          destination_fqdns: ["time.windows.com"]
+          protocols: ["UDP"]
+          destination_ports: ["123"]
+        - name: "login windows.net"
+          source_addresses: ["10.0.0.0/24"]
+          destination_fqdns: ["login.windows.net"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+        - name: "msftconnecttest"
+          source_addresses: ["10.0.0.0/24"]
+          destination_fqdns: ["www.msftconnecttest.com"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+  application_rule_collections:
+    - action: "Allow"
+      name: "AVDOptionalApplicationRules"
+      priority: 600
+      rules:
+        - name: "Windows"
+          source_addresses: ["10.0.0.0/24"]
+          destination_fqdn_tags: ["WindowsUpdate", "WindowsDiagnostics", "MicrosoftActiveProtectionService"]
+          protocols:
+            - port: 443
+              type: "Https"
+        - name: "Events"
+          source_addresses: ["10.0.0.0/24"]
+          destination_fqdns: ["*.events.data.microsoft.com"]
+          protocols:
+            - port: 443
+              type: "Https"
+        - name: "sfx"
+          source_addresses: ["10.0.0.0/24"]
+          destination_fqdns: ["*.sfx.ms"]
+          protocols:
+            - port: 443
+              type: "Https"
+        - name: "digicert"
+          source_addresses: ["10.0.0.0/24"]
+          destination_fqdns: ["*.digicert.com"]
+          protocols:
+            - port: 443
+              type: "Https"
+        - name: "Azure DNS"
+          source_addresses: ["10.0.0.0/24"]
+          destination_fqdns: ["*.azure-dns.com", "*.azure-dns.net"]
+          protocols:
+            - port: 443
+              type: "Https"
+
+m365:
+  priority: 2000
+  network_rule_collections:
+    - action: "Allow"
+      name: "M365NetworkRules"
+      priority: 500
+      rules:
+        - name: "M365"
+          source_addresses: ["10.0.0.0/24"]
+          destination_addresses: ["Office365.Common.Allow.Required"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+
+internet:
+  priority: 3000
+  network_rule_collections:
+    - action: "Allow"
+      name: "InternetNetworkRules"
+      priority: 500
+      rules:
+        - name: "Internet"
+          source_addresses: ["10.0.0.0/24"]
+          destination_addresses: ["*"]
+          protocols: ["TCP"]
+          destination_ports: ["443", "80"]

--- a/optionTwo/firewall_rules_nonprod.yaml
+++ b/optionTwo/firewall_rules_nonprod.yaml
@@ -1,0 +1,60 @@
+# Non-production environment - More permissive firewall rules
+avd_core:
+  priority: 1000
+  network_rule_collections:
+    - action: "Allow"
+      name: "AVDCoreNetworkRules"
+      priority: 500
+      rules:
+        - name: "Login to Microsoft"
+          source_addresses: ["10.100.0.0/16"]  # Broader range for nonprod
+          destination_fqdns: ["login.microsoftonline.com"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+        - name: "AVD"
+          source_addresses: ["10.100.0.0/16"]
+          destination_addresses: ["WindowsVirtualDesktop", "AzureFrontDoor.Frontend", "AzureMonitor"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+        - name: "DNS"
+          source_addresses: ["10.100.0.0/16"]
+          destination_addresses: ["AzureDNS"]
+          protocols: ["TCP", "UDP"]
+          destination_ports: ["53"]
+
+# Non-production tools and debugging
+nonprod_tools:
+  priority: 1500
+  network_rule_collections:
+    - action: "Allow"
+      name: "NonProductionTools"
+      priority: 500
+      rules:
+        - name: "GitHub"
+          source_addresses: ["10.0.0.0/8"]
+          destination_fqdns: ["github.com", "api.github.com", "*.githubusercontent.com"]
+          protocols: ["TCP"]
+          destination_ports: ["443", "22"]
+        - name: "NPM Registry"
+          source_addresses: ["10.0.0.0/8"]
+          destination_fqdns: ["registry.npmjs.org", "*.npmjs.com"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+        - name: "Docker Hub"
+          source_addresses: ["10.0.0.0/8"]
+          destination_fqdns: ["registry-1.docker.io", "*.docker.com", "*.docker.io"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+
+internet:
+  priority: 9000  # Higher priority (less restrictive) for nonprod
+  network_rule_collections:
+    - action: "Allow"
+      name: "InternetNetworkRules"
+      priority: 500
+      rules:
+        - name: "Internet"
+          source_addresses: ["10.0.0.0/8"]  # Broader range
+          destination_addresses: ["*"]
+          protocols: ["TCP", "UDP"]
+          destination_ports: ["443", "80", "8080", "3000", "8000"]  # Additional nonprod ports

--- a/optionTwo/firewall_rules_prod.yaml
+++ b/optionTwo/firewall_rules_prod.yaml
@@ -1,0 +1,79 @@
+# Production environment - Restrictive firewall rules
+avd_core:
+  priority: 1000
+  network_rule_collections:
+    - action: "Allow"
+      name: "AVDCoreNetworkRules"
+      priority: 500
+      rules:
+        - name: "Login to Microsoft"
+          source_addresses: ["10.100.0.0/24"]  # Specific subnet only
+          destination_fqdns: ["login.microsoftonline.com"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+        - name: "AVD"
+          source_addresses: ["10.100.0.0/24"]
+          destination_addresses: ["WindowsVirtualDesktop", "AzureFrontDoor.Frontend", "AzureMonitor"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+        - name: "GCS"
+          source_addresses: ["10.100.0.0/24"]
+          destination_fqdns: ["gcs.prod.monitoring.core.windows.net"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+        - name: "DNS"
+          source_addresses: ["10.100.0.0/24"]
+          destination_addresses: ["AzureDNS"]
+          protocols: ["TCP", "UDP"]
+          destination_ports: ["53"]
+        - name: "KMS"
+          source_addresses: ["10.100.0.0/24"]
+          destination_fqdns: ["kms.core.windows.net"]
+          protocols: ["TCP"]
+          destination_ports: ["1688"]
+
+m365:
+  priority: 2000
+  network_rule_collections:
+    - action: "Allow"
+      name: "M365NetworkRules"
+      priority: 500
+      rules:
+        - name: "M365"
+          source_addresses: ["10.0.0.0/24"]  # Specific production subnet
+          destination_addresses: ["Office365.Common.Allow.Required"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+
+# Production security and monitoring
+security_monitoring:
+  priority: 2500
+  network_rule_collections:
+    - action: "Allow"
+      name: "SecurityMonitoringRules"
+      priority: 500
+      rules:
+        - name: "Azure Security Center"
+          source_addresses: ["10.0.0.0/16"]
+          destination_addresses: ["AzureSecurityCenter"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+        - name: "Windows Defender ATP"
+          source_addresses: ["10.0.0.0/16"]
+          destination_fqdns: ["*.securitycenter.windows.com"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]
+
+# Very restrictive internet access for production
+internet:
+  priority: 8000
+  network_rule_collections:
+    - action: "Allow"
+      name: "RestrictedInternetRules"
+      priority: 500
+      rules:
+        - name: "HTTPS Only"
+          source_addresses: ["10.0.0.0/24"]  # Only specific production subnet
+          destination_addresses: ["*"]
+          protocols: ["TCP"]
+          destination_ports: ["443"]  # HTTPS only

--- a/optionTwo/locals.tf
+++ b/optionTwo/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  # Load firewall rules from YAML file
+  firewall_rules = yamldecode(file(var.firewall_rules_config_file))
+}

--- a/optionTwo/main.tf
+++ b/optionTwo/main.tf
@@ -1,0 +1,64 @@
+# Option 2: YAML file-based configuration
+
+resource "azurerm_resource_group" "azfw-rg" {
+  location = var.location
+  name     = var.resource_group_name
+}
+
+module "firewall_policy" {
+  source = "Azure/avm-res-network-firewallpolicy/azurerm"
+  enable_telemetry    = var.enable_telemetry
+  name                = var.firewall_policy_name
+  location            = var.location
+  resource_group_name = azurerm_resource_group.azfw-rg.name
+  firewall_policy_dns = {
+    proxy_enabled = true
+  }
+}
+
+# Dynamic rule collection groups using YAML configuration
+module "rule_collection_groups" {
+  source   = "Azure/avm-res-network-firewallpolicy/azurerm//modules/rule_collection_groups"
+  for_each = local.firewall_rules
+
+  firewall_policy_rule_collection_group_firewall_policy_id = module.firewall_policy.resource.id
+  firewall_policy_rule_collection_group_name               = "${title(each.key)}RuleCollectionGroup"
+  firewall_policy_rule_collection_group_priority           = each.value.priority
+
+  # Network rule collections
+  firewall_policy_rule_collection_group_network_rule_collection = [
+    for collection in try(each.value.network_rule_collections, []) : {
+      action   = collection.action
+      name     = collection.name
+      priority = collection.priority
+      rule = [
+        for rule in collection.rules : {
+          name                  = rule.name
+          source_addresses      = rule.source_addresses
+          destination_fqdns     = try(rule.destination_fqdns, null)
+          destination_addresses = try(rule.destination_addresses, null)
+          protocols             = rule.protocols
+          destination_ports     = rule.destination_ports
+        }
+      ]
+    }
+  ]
+
+  # Application rule collections
+  firewall_policy_rule_collection_group_application_rule_collection = [
+    for collection in try(each.value.application_rule_collections, []) : {
+      action   = collection.action
+      name     = collection.name
+      priority = collection.priority
+      rule = [
+        for rule in collection.rules : {
+          name                  = rule.name
+          source_addresses      = rule.source_addresses
+          destination_fqdns     = try(rule.destination_fqdns, null)
+          destination_fqdn_tags = try(rule.destination_fqdn_tags, null)
+          protocols             = rule.protocols
+        }
+      ]
+    }
+  ]
+}

--- a/optionTwo/terraform.tf
+++ b/optionTwo/terraform.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.71, < 5.0.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.0, < 4.0.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = ""
+}

--- a/optionTwo/terraform.tfvars
+++ b/optionTwo/terraform.tfvars
@@ -1,0 +1,8 @@
+# Option 2: terraform.tfvars for YAML-based configuration
+enable_telemetry = true
+location = "australiaeast"
+firewall_policy_name = "azfw-policy-option2"
+resource_group_name = "azfwpolicy-rg-option2"
+
+# Path to the YAML configuration file
+firewall_rules_config_file = "firewall_rules.yaml"

--- a/optionTwo/terraform_nonprod.tfvars
+++ b/optionTwo/terraform_nonprod.tfvars
@@ -1,0 +1,6 @@
+# Non-Production Environment - More permissive rules
+enable_telemetry = true
+location = "australiaeast"
+firewall_policy_name = "azfw-policy-option2-nonprod"
+resource_group_name = "azfwpolicy-rg-option2"
+firewall_rules_config_file = "firewall_rules_nonprod.yaml"

--- a/optionTwo/terraform_prod.tfvars
+++ b/optionTwo/terraform_prod.tfvars
@@ -1,0 +1,6 @@
+# Production Environment - Restricted rules
+enable_telemetry = true
+location = "australiaeast"
+firewall_policy_name = "azfw-policy-option2-prod"
+resource_group_name = "azfwpolicy-rg-option2"
+firewall_rules_config_file = "firewall_rules_prod.yaml"

--- a/optionTwo/validate-firewall-rules.ps1
+++ b/optionTwo/validate-firewall-rules.ps1
@@ -1,0 +1,106 @@
+# PowerShell script to validate firewall rules YAML files
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$YamlFile
+)
+
+function Test-YamlStructure {
+    param([hashtable]$Config)
+    
+    $errors = @()
+    
+    foreach ($groupName in $Config.Keys) {
+        $group = $Config[$groupName]
+        
+        # Check required fields
+        if (-not $group.priority) {
+            $errors += "Group '$groupName': Missing priority"
+        }
+        
+        # Validate network rule collections
+        if ($group.network_rule_collections) {
+            foreach ($collection in $group.network_rule_collections) {
+                if (-not $collection.action -or -not $collection.name -or -not $collection.priority) {
+                    $errors += "Group '$groupName': Network collection missing required fields (action, name, priority)"
+                }
+                
+                foreach ($rule in $collection.rules) {
+                    if (-not $rule.name -or -not $rule.protocols -or -not $rule.destination_ports) {
+                        $errors += "Group '$groupName': Network rule '$($rule.name)' missing required fields"
+                    }
+                    
+                    if (-not $rule.destination_fqdns -and -not $rule.destination_addresses) {
+                        $errors += "Group '$groupName': Network rule '$($rule.name)' must have either destination_fqdns or destination_addresses"
+                    }
+                }
+            }
+        }
+        
+        # Validate application rule collections
+        if ($group.application_rule_collections) {
+            foreach ($collection in $group.application_rule_collections) {
+                if (-not $collection.action -or -not $collection.name -or -not $collection.priority) {
+                    $errors += "Group '$groupName': Application collection missing required fields (action, name, priority)"
+                }
+                
+                foreach ($rule in $collection.rules) {
+                    if (-not $rule.name -or -not $rule.protocols) {
+                        $errors += "Group '$groupName': Application rule '$($rule.name)' missing required fields"
+                    }
+                    
+                    if (-not $rule.destination_fqdns -and -not $rule.destination_fqdn_tags) {
+                        $errors += "Group '$groupName': Application rule '$($rule.name)' must have either destination_fqdns or destination_fqdn_tags"
+                    }
+                }
+            }
+        }
+    }
+    
+    return $errors
+}
+
+try {
+    Write-Host "Validating YAML file: $YamlFile" -ForegroundColor Green
+    
+    # Check if file exists
+    if (-not (Test-Path $YamlFile)) {
+        Write-Host "ERROR: File '$YamlFile' not found!" -ForegroundColor Red
+        exit 1
+    }
+    
+    # Load and parse YAML (requires powershell-yaml module)
+    if (-not (Get-Module -ListAvailable -Name powershell-yaml)) {
+        Write-Host "Installing powershell-yaml module..." -ForegroundColor Yellow
+        Install-Module -Name powershell-yaml -Force -Scope CurrentUser
+    }
+    
+    Import-Module powershell-yaml
+    $yamlContent = Get-Content $YamlFile -Raw
+    $config = ConvertFrom-Yaml $yamlContent
+    
+    # Validate structure
+    $validationErrors = Test-YamlStructure $config
+    
+    if ($validationErrors.Count -eq 0) {
+        Write-Host "✅ YAML validation passed!" -ForegroundColor Green
+        Write-Host "Found $($config.Keys.Count) rule collection groups:" -ForegroundColor Cyan
+        
+        foreach ($groupName in $config.Keys) {
+            $group = $config[$groupName]
+            $networkCollections = if ($group.network_rule_collections) { $group.network_rule_collections.Count } else { 0 }
+            $appCollections = if ($group.application_rule_collections) { $group.application_rule_collections.Count } else { 0 }
+            
+            Write-Host "  - $groupName (Priority: $($group.priority), Network: $networkCollections, App: $appCollections)" -ForegroundColor White
+        }
+    } else {
+        Write-Host "❌ YAML validation failed with errors:" -ForegroundColor Red
+        foreach ($error in $validationErrors) {
+            Write-Host "  - $error" -ForegroundColor Red
+        }
+        exit 1
+    }
+    
+} catch {
+    Write-Host "ERROR: Failed to parse YAML file: $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}

--- a/optionTwo/variables.tf
+++ b/optionTwo/variables.tf
@@ -1,0 +1,34 @@
+# Option 2: YAML-based configuration variables
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+This variable controls whether or not telemetry is enabled for the module.
+For more information see https://aka.ms/avm/telemetryinfo.
+If it is set to false, then no telemetry will be collected.
+DESCRIPTION
+}
+
+variable "location" {
+  type        = string
+  default     = "australiaeast"
+  description = "The Azure region where resources will be deployed"
+}
+
+variable "firewall_policy_name" {
+  type        = string
+  default     = "azfw-policy-option2"
+  description = "The name of the firewall policy"
+}
+
+variable "resource_group_name" {
+  type        = string
+  default     = "azfwpolicy-rg-option2"
+  description = "The name of the resource group"
+}
+
+variable "firewall_rules_config_file" {
+  type        = string
+  default     = "firewall_rules.yaml"
+  description = "Path to the YAML file containing firewall rules configuration"
+}


### PR DESCRIPTION
This pull request introduces two alternative approaches for managing Azure Firewall rule configuration in Terraform: Option 1 (variable-based, declarative configuration) and Option 3 (template-based, compositional configuration). Each option is documented with its respective pros, cons, and usage instructions, and includes sample configurations and supporting files.

**Option 1: Variable-Based Configuration**

Configuration structure and type safety:

* Adds a comprehensive `README.md` describing the variable-based approach, its pros/cons, and usage scenarios.
* Implements complex variable definitions in `variables.tf` with strict type validation for firewall rule collection groups, supporting both network and application rules.
* Provides a sample `terraform.tfvars` with detailed example rules for multiple rule groups, demonstrating how to structure and extend rule sets.

Deployment and module usage:

* Defines the main Terraform configuration in `main.tf`, using `for_each` to dynamically create rule collection groups and pass structured variables to the firewall policy modules.
* Specifies provider and version requirements in `terraform.tf`, ensuring compatibility and repeatability.

**Option 3: Template-Based Configuration**

Template abstraction and composition:

* Adds a detailed `README.md` explaining the template-based approach, including instructions for enabling rule sets, managing network segments, and extending rule templates.
* Implements reusable rule templates and compositional logic in `locals.tf`, allowing standardized rule definitions and easy selection of enabled rule sets via variables.

These changes provide clear, maintainable alternatives for firewall rule management, catering to teams with different expertise and deployment needs.